### PR TITLE
change display.DisplayBufferRef to display.DisplayRef in display.py

### DIFF
--- a/esphome/components/lilygo_t5_47_display/display.py
+++ b/esphome/components/lilygo_t5_47_display/display.py
@@ -48,7 +48,7 @@ async def to_code(config):
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))
     cg.add(var.set_clear_screen(config[CONF_CLEAR]))


### PR DESCRIPTION
```
  File "/config/esphome/.esphome/external_components/2851613f/esphome/components/lilygo_t5_47/display/__init__.py", line 45, in to_code
    config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
AttributeError: module 'esphome.components.display' has no attribute 'DisplayBufferRef'
```